### PR TITLE
Remove mdocCheck SBT Command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
     - name: test
       if: (NOT branch =~ /^release\/.*$/)
       # When running scripted tests targeting multiple SBT versions, we must first publish locally for all SBT versions
-      script: sbt "^ publishLocal" "^ scripted" "mdocCheck"
+      script: sbt "^ publishLocal" "^ scripted" "mdoc"
     - name: release
       if: (branch =~ /^release\/.*$/)
       env:

--- a/build.sbt
+++ b/build.sbt
@@ -50,14 +50,6 @@ lazy val root = (project in file("."))
       "SBT_RELEASE_VERSION" -> sbtReleaseVersion,
       "MDOC_VERSION" -> mdocVersion,
     ),
-    commands += Command
-      .command("mdocCheck") { state =>
-        val newState = Project
-          .extract(state)
-          .appendWithoutSession(Seq(mdocExtraArguments += "--check"), state)
-        Project.extract(newState).runInputTask(mdoc, "", newState)
-        state
-      },
     // sbt-bintray settings
     publishMavenStyle := false,
     bintrayRepository := "sbt-plugins",


### PR DESCRIPTION
`mdoc`'s `--check` option is breaking the build because `--check` is not actually Dry Run mode, but actually checks if generating the output Markdown file will differ against the existing output Markdown file (see https://scalameta.org/mdoc/docs/installation.html#help).

In the meantime, while waiting for the feature to run in Dry Run mode (scalameta/mdoc#163), run `mdoc` in Travis CI build, but don't commit/push the changes.