### PR TITLE
Remove cross SBT building for scripted task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       script: sbt mdoc
     - stage: test
       # When running scripted tests targeting multiple SBT versions, we must first publish locally for all SBT versions
-      script: sbt "^ test" "^ publishLocal" "^ scripted"
+      script: sbt "^ test" "^ publishLocal" "scripted"
     - stage: release
       if: (branch =~ /^release\/.*$/)
       env:

--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ lazy val sbtReleaseMdoc = project
       releaseStepCommandAndRemaining("^ test"),
       // When running scripted tests targeting multiple SBT versions, we must first publish locally for all SBT versions
       releaseStepCommandAndRemaining("^ publishLocal"),
-      releaseStepCommandAndRemaining("^ scripted"),
+      releaseStepInputTask(scripted),
      */
     ),
   )


### PR DESCRIPTION
There is no need to cross build `scripted` task as the SBT version it will run with depends on the version configured in the scripted test's `project/build.properties` file. This will greatly reduce build times.