### PR TITLE
Update scalafmt version to 2.2.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.1.1"
+version = "2.2.1"
 
 trailingCommas = always
 


### PR DESCRIPTION
Update `scalafmt` to match version used by `sbt-scalafmt` (which was updated to version `2.2.1` in #37).