### PR TITLE
Update SBT to 1.3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,9 @@ lazy val sbtReleaseMdoc = project
   .in(file("sbt-release-mdoc"))
   .settings(
     moduleName := (ThisBuild / name).value,
-    crossSbtVersions := Seq("1.2.8"),
+    crossSbtVersions := Seq(
+      "1.3.3",
+    ),
     // mdoc must be declared before sbt-mdoc due to package/class name conflict (mdoc.Main)
     // The compiler looks up classes in the build classpath order
     libraryDependencies ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-release-mdoc/src/sbt-test/sbt-1.0/commit/project/build.properties
+++ b/sbt-release-mdoc/src/sbt-test/sbt-1.0/commit/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-release-mdoc/src/sbt-test/sbt-1.0/commit/project/plugins.sbt
+++ b/sbt-release-mdoc/src/sbt-test/sbt-1.0/commit/project/plugins.sbt
@@ -6,6 +6,8 @@ sys.props.get("plugin.version") match {
                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
 
+useCoursier := false
+
 addSbtPlugin("com.github.daniel-shuy" % "sbt-scripted-scalatest" % "1.1.1")
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8"
 

--- a/sbt-release-mdoc/src/sbt-test/sbt-1.0/mdoc/project/build.properties
+++ b/sbt-release-mdoc/src/sbt-test/sbt-1.0/mdoc/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-release-mdoc/src/sbt-test/sbt-1.0/mdoc/project/plugins.sbt
+++ b/sbt-release-mdoc/src/sbt-test/sbt-1.0/mdoc/project/plugins.sbt
@@ -6,6 +6,8 @@ sys.props.get("plugin.version") match {
                          |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
 }
 
+useCoursier := false
+
 addSbtPlugin("com.github.daniel-shuy" % "sbt-scripted-scalatest" % "1.1.1")
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8"
 


### PR DESCRIPTION
`useCoursier := false` is required in `scripted` tests due to issue with Coursier in SBT 1.3 (see sbt/sbt#5227)