### PR TITLE
Move "Cache NPM" step before "Set up Node.js" step in build Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,6 @@ jobs:
     - name: Checkout with GIT
       uses: actions/checkout@v2
 
-    - name: Set up Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: 13
-
     - name: Cache NPM
       uses: actions/cache@v1
       with:
@@ -27,6 +22,11 @@ jobs:
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
           ${{ runner.os }}-node-
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 13
 
     - name: Update NPM
       run: npm install --global npm@latest


### PR DESCRIPTION
Currently, running `Cache NPM` after `Set up Node.js` doesn't seem to have any effect on performance. May need to run `Cache NPM` before `Set up Node.js` for the cache to work.