### PR TITLE
Cache SBT coursier cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,11 @@ jobs:
       with:
         path: ~/.ivy2/cache
         key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}
+    - name: Cache SBT coursier cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.coursier/cache
+        key: ${{ runner.os }}-sbt-coursier-cache-${{ hashFiles('**/build.sbt') }}
     - name: Cache SBT
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
Since [actions/cache](https://github.com/actions/cache)'s cache size limit has been increased to 5GB in version [1.1.1+](https://github.com/actions/cache/releases/tag/v1.1.1), it is now possible to cache SBT coursier's cache (see https://github.com/actions/cache/issues/59#issuecomment-552846834-permalink)