### PR TITLE
Feature/renovate

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,7 +27,7 @@ rules:
   object-property-newline: error
   quotes:
     - error
-    - single
+    - double
   semi:
     - error
     - never

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,8 +1,8 @@
 {
   extends: [
-    'config:base',
+    "config:base",
   ],
-  rebaseWhen: 'behind-base-branch',
+  rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
   automerge: true,
   major: {
@@ -17,27 +17,27 @@
         TODO: Remove after https://github.com/scalatest/scalatest/issues/1766 is fixed
       */
       packageNames: [
-        'org.scalatest:scalatest',
+        "org.scalatest:scalatest",
       ],
-      versioning: 'semver',
+      versioning: "semver",
     },
     {
       packageNames: [
-        'org.scalameta:mdoc',
+        "org.scalameta:mdoc",
       ],
       updateTypes: [
-        'minor',
-        'patch',
+        "minor",
+        "patch",
       ],
       enabled: false,
     },
     {
       packageNames: [
-        'org.scalameta:sbt-scalafmt',
+        "org.scalameta:sbt-scalafmt",
       ],
       automerge: false,
       prBodyNotes: [
-        ':warning: .scalafmt.conf must be updated manually',
+        ":warning: .scalafmt.conf must be updated manually",
       ],
     },
   ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,7 @@
   ],
   rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
+  prCreation: "not-pending",
   automerge: true,
   major: {
     automerge: false,

--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,7 @@
   rebaseWhen: "behind-base-branch",
   stabilityDays: 1,
   prCreation: "not-pending",
+  masterIssue: true,
   automerge: true,
   major: {
     automerge: false,


### PR DESCRIPTION
This PR suppresses Renovate PRs for 1 day so that the build does not fail if the dependency is still in staging (see https://docs.renovatebot.com/configuration-options/#suppress-branchpr-creation-for-x-days)