### PR TITLE
Remove Renovate stabilityDays

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
     "config:base",
   ],
   rebaseWhen: "behind-base-branch",
-  stabilityDays: 1,
   prCreation: "not-pending",
   dependencyDashboard: true,
   automerge: true,


### PR DESCRIPTION
Remove Renovate [stabilityDays](https://docs.renovatebot.com/configuration-options/#stabilitydays) as it is preventing `renovate` NPM dependency from being automerged